### PR TITLE
Update remark-validate-links

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "remark-preset-lint-recommended": "^6.0.0",
     "remark-retext": "^5.0.0",
     "remark-toc": "^8.0.0",
-    "remark-validate-links": "^11.0.0",
+    "remark-validate-links": "^12.0.0",
     "retext-english": "^4.0.0",
     "retext-preset-wooorm": "^4.0.0",
     "unified": "^10.0.0"


### PR DESCRIPTION
The breaking change in `remark-validate-links` is that it requires Node.js 14+, which was already the case for this `remark-preset-wooorm`.

It also updates `unified-engine`, but not in a breaking manner. Only its types are used by `remark-validate-links`, but they are not part of the public interface of `remark-preset-wooorm`. package.